### PR TITLE
Change the ses-callback queue functionality

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,13 +7,15 @@ import uuid
 from celery import Celery
 from flask import Flask, jsonify
 
-QUEUE_NAME = os.environ['NOTIFICATION_QUEUE_PREFIX'] + "ses-callbacks"
+QUEUE_NAME = "ses-callbacks"
+QUEUE_PREFIX = os.environ['NOTIFICATION_QUEUE_PREFIX']
 
 
 CONFIG = {
     'BROKER_URL': 'sqs://',
     'BROKER_TRANSPORT_OPTIONS': {
         'region': 'eu-west-1',
+        'queue_name_prefix': QUEUE_PREFIX,
         'visibility_timeout': 310,
     },
 }


### PR DESCRIPTION
Change the ses-callback queue functionality to use the queue_name_prefix functionality.

This affects the messages being written to the queue.

Before this change (where dev-d-ecs is an example of the queue prefix):

 ... "delivery_info": {"exchange": "", "routing_key": "dev-d-ecsses-callbacks"} ...

After this change:

 ... "delivery_info": {"exchange": "", "routing_key": "ses-callbacks"} ...

This makes it more consistent with messages on the other queues. For example 'periodic-tasks':

 ... "delivery_info": {"exchange": "", "routing_key": "periodic-tasks"} ...

This is a problem because of the way Celery deals with these messages.

It appears that celery will try to create a new consumer for whatever it sees in the routing_key.

If the queue does exist no problem.

However if you have 'predefined_queues' defined you will get a worker crash with the following error:

kombu.transport.SQS.UndefinedQueueException: Queue with name 'dev-d-ecsdev-d-ecsses-callbacks' must be defined in 'predefined_queues'.

You can see the prefix is being applied to the 'routing_key' and as such you get it twice.