### PR TITLE
Dockerfile: Add missing git dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,9 +6,10 @@ RUN apt-get update \
     libcurl4 \
     libcurl4-openssl-dev \
     libssl-dev \
-    curl && \
-    apt-get -y clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/*
+    curl \
+    git \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
 
 WORKDIR /app
 


### PR DESCRIPTION
This repo doesn't seem to have CI, so I've tested building the Docker image locally instead