### PR TITLE
chore: update utils to 100.2.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,2 @@
 celery[sqs]==5.4.0
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@89.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@100.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,13 +81,13 @@ markupsafe==3.0.2
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@89.2.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@100.2.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
 packaging==24.2
     # via gunicorn
-phonenumbers==8.13.50
+phonenumbers==9.0.10
     # via notifications-utils
 prompt-toolkit==3.0.48
     # via click-repl
@@ -101,7 +101,8 @@ python-dateutil==2.9.0.post0
     # via
     #   botocore
     #   celery
-python-json-logger==2.0.7
+    #   notifications-utils
+python-json-logger==3.3.0
     # via notifications-utils
 pytz==2024.2
     # via notifications-utils


### PR DESCRIPTION
Bump utils to 100.2.0

 ## 100.2.0

* add  fields to pre/post request flask logs

 ## 100.1.0

* Updated  to version 9.0.9 to keep phonenumber metadata uptodate

 ## 100.0.0

*  is now a required argument of  (apps have already been updated)

 ## 99.8.0

* Add new version of GOV.UK brand to email template, behind a flag

 ## 99.7.0

* Update economy letter transit dates to max 8 days

 ## 99.6.0

* Improve celery json logging. Include beat with separate log level options and testing

 ## 99.5.2

* Make inheritence of annotations on SerialisedModel work on both the class and its instances

 ## 99.5.1

* Bump minimum Flask version to 3.1.1

 ## 99.5.0

* Update economy letter transit date to 5 days

 ## 99.4.1

* Fix celery beat logging so that it will log in json

 ## 99.4.0

* Add celery logging configuration for json logging

 ## 99.3.4

* : don't emit early log if called synchronously

 ## 99.3.3

* Fix bug with non-SMS templates considering international SMS limits

 ## 99.3.2

* Stops counting Crown Dependency phone numbers in CSV file as international

 ## 99.3.1

* Bump  to version 3

 ## 99.3.0

* Adds
* Adds  (initialise per  to enable this check)

 ## 99.2.0

* Add s3 multipart upload lifecycle (create, upload, complete, abort)

 ## 99.1.2

* Normalise unusual dashes and spacing characters in phone numbers

 ## 99.1.1

* Bump ruff to latest version

 ## 99.1.0

* Adds support for economy mail in get_min_and_max_days_in_transit, with delivery estimated between 2 and 6 days

 ## 99.0.0

* NOTABLE CHANGE: Celery tasks emit an early log message when starting, with a customisable log level to allow this to be disabled for high-volume tasks. When upgrading past this version you may want to pass the extra argument  to the task decorator of your most heavily-called tasks to reduce the effect on log volume
* Annotates automatic celery task log messages with

 ## 98.0.1

* Moves from  to  for package configuation
* Changes ruff config from  to

 ## 98.0.0

* Update rate multipliers for international SMS to have values for 1 April 2025 onwards. When used in notifications-api and notifications-admin this change will affect the billing of text messages the pricing shown.

 ## 97.0.5

* Fix mailto: URLs in Markdown links

 ## 97.0.4

* Fix inset text block styling

 ## 97.0.3

* Bump minimum jinja2 version to 3.1.6

 ## 97.0.2

* Fix external link redirect

 ## 97.0.1

* Fix QR code URL with '&' encoded as '&amp;'

 ## 97.0.0

* for bilingual letters preview, only show barcodes on the first page (patch).
* rename  argument to  (major).

 ## 96.0.0

* BREAKING CHANGE: the  module has been moved to  to make space for gunicorn-related utils that don't have the restricted-import constraints of the gunicorn defaults. Imports of  should be changed to .
* Added  custom gunicorn worker class.

 ## 95.2.0

* Implement

 ## 95.1.2

* Fix to the number of arguments the  of the  class takes.

 ## 95.1.1

* Add  rule to linter config (checks for inapplicable uses of )

 ## 95.1.0

* Adds log message and statsd metric for retried celery tasks

 ## 95.0.0

* Reverts 92.0.0 to restore new validation code

 ## 94.0.1

* Add  to

 ## 94.0.0

*  will now copy  instead of . Apps should maintain their own , if required
* Replaces  formatter with
* Upgrades  to version 0.9.2

 ## 93.2.1

* Replaces symlink at  with a duplicate file

 ## 93.2.0

* logging: add verbose eventlet context to app.request logs if request_time is over a threshold

 ## 93.1.0

* Introduce  config variable for separate control of handler log level

 ## 93.0.0

* BREAKING CHANGE: logging: all contents of  have been moved to  because they all assume a flask(-like) environment and this way we don't implicitly import all of flask etc. every time anything under  is imported.
* Adds  to  logs when available.
* Adds ability to track eventlet's switching of greenlets and annotate  logs with useful metrics when the flask config parameter  is set and the newly provided function  is installed as a greenlet trace hook.

 ## 92.1.1

* Bump minimum version of Usage: jinja2 [options] <input template> <input data>

Options:
  --version             show program's version number and exit
  -h, --help            show this help message and exit
  --format=FORMAT       format of input variables: auto, env, ini, json,
                        querystring, toml, xml, yaml, yml
  -e EXTENSIONS, --extension=EXTENSIONS
                        extra jinja2 extensions to load
  -D key=value          Define template variable in the form of key=value
  -s SECTION, --section=SECTION
                        Use only this section from the configuration
  --strict              Disallow undefined variables to be used within the
                        template
  -o FILE, --outfile=FILE
                        File to use for output. Default is stdout. to 3.1.5

 ## 92.1.0

* RequestCache: add CacheResultWrapper to allow dynamic cache decisions

 ## 92.0.2

* Downgrade minimum version of  to 2.32.3

 ## 92.0.1

* Bumps core dependencies to latest versions

 ## 92.0.0

* Restores old validation code so later utils changes can be added to api, admin etc.

 ## 91.1.2

* Adds rule N804 (invalid-first-argument-name-for-class-method) to linter config

 ## 91.1.1

* Remove hangul filler character from rendered emails

 ## 91.1.0

* bump all libs in requirements_for_test_common.in

 ## 91.0.4

* Don’t copy config when bumping utils version

 ## 91.0.3

* Fix validating supported international country codes for phone numbers without a leading + that look a bit like UK numbers

 ## 91.0.2

* Bumps requests to newer version

 ## 91.0.1

* Adds public utility method to check if a phonenumber is international (with correct handling for OFCOM TV numbers)
* Updates PhoneNumber.get_international_phone_info to return the correct info for OFCOM TV numbers

 ## 91.0.0

* BREAKING CHANGE: All standalone functions for validating, normalising and formatting phone numbers has been removed from notifications_utils/recipient_validation/phone_number.py, and are replaced and encapsualated entirely with a single  class. All code that relies on validation, normalisation or fomratting of a phone number must be re-written to use instances of  instead.

 ## 90.0.0

* Allow leading empty columns in CSV files
* Change second argument of  (this argument is not used in other apps) ***

Complete changes: https://github.com/alphagov/notifications-utils/compare/89.2.0...100.2.0